### PR TITLE
Fixed header pixel oddity for gameroom.

### DIFF
--- a/web/static/gameroom.css
+++ b/web/static/gameroom.css
@@ -1,8 +1,6 @@
 html, body {
 	margin: 0px;
 	padding: 0px;
-	height: 100%;
-	width: 100%;
 	background: url( "background.jpg" );
 	background-size: cover;
 	background-position: center;
@@ -10,7 +8,7 @@ html, body {
 }
 
 #cf-game-col {
-	font-size: 0px;
+    font-size: 0px;
     padding: 0px;
     margin: 0px;
 }

--- a/web/static/page.css
+++ b/web/static/page.css
@@ -1,3 +1,8 @@
+html, body {
+    height: 100%;
+    width: 100%;
+}
+
 html {
     background-image: linear-gradient(#428050, #30582C);
 }

--- a/web/templates/api.html
+++ b/web/templates/api.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
   <head>
     {% include 'header.html' %}

--- a/web/templates/contact.html
+++ b/web/templates/contact.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
   <head>
     {% include 'header.html' %}

--- a/web/templates/game_rules.html
+++ b/web/templates/game_rules.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
   <head>
     {% include 'header.html' %}

--- a/web/templates/gameroom_list.html
+++ b/web/templates/gameroom_list.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
   <head>
     {% include 'header.html' %}

--- a/web/templates/get_started.html
+++ b/web/templates/get_started.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
   <head>
     {% include 'header.html' %}

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
   <head>
     {% include 'header.html' %}


### PR DESCRIPTION
Turns out the non-gameroom.html webpages were not standards compliant since
they were not marked with "!DOCTYPE html". Fixed this by marking them.

Also migrated setting the <html> height and width out of gameroom.css into
page.css so all pages will be able to use the full size.